### PR TITLE
Use static version identifier for Openfire dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
     <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
-    <date>2024-11-20</date>
+    <date>2025-06-12</date>
     <minServerVersion>5.0.0</minServerVersion>
     <adminconsole>
         <tab id="tab-webclients" name="${admin.sidebar.webclients.name}" description="${admin.sidebar.webclients.description}" url="xmppweb-config.jsp">

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>5.0.0-beta</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>xmppweb</artifactId>


### PR DESCRIPTION
Instead of depending on 5.0.0-SNAPSHOT, use a version identifier that is deterministic.